### PR TITLE
Add ability to limit projects exported

### DIFF
--- a/.sentry-exporter-example.yaml
+++ b/.sentry-exporter-example.yaml
@@ -1,6 +1,7 @@
 api_url: http://mysentry-instance.com/api/0/  # if not specified, defaults to https://sentry.io/api/0/
 listen_address: :8080                         # if not specified, defaults to :9142
 organisation_name: my-first-organisation      # required. TODO: Obtain this via API call for default
+project_include:                              # if not specified, defaults to all projects
 timeout: 3                                    # if not specified, defaults to 60 seconds
 token: 12345abcdef67890ghijkl                 # required
 ttl_organisation: 600                         # if not specified, defaults to 86400 seconds (1 day)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ You can also specify any of the settings via ENV variables.
 | api_url | SENTRY_EXPORTER_API_URL | https://sentry.io/api/0/ | URL that points to your Sentry API
 | listen_address | SENTRY_EXPORTER_LISTEN_ADDRESS | :9142 | Address to start the web server on
 | organisation_name | SENTRY_EXPORTER_ORGANISATION_NAME | "" | This is a **required** setting. The organisation slug for your account.  This is queried to extract a list of teams
+| project_includes | SENTRY_EXPORTER_PROJECT_INCLUDES | "" | Comma separated list of project slugs to include in the export
 | timeout | SENTRY_EXPORTER_TIMEOUT | 60 | The maximum amount of seconds to wait for the Sentry API to respond
 | token | SENTRY_EXPORTER_TOKEN | "" | This is a **required** setting. It allows communication with the Sentry API. More details below
 | ttl_organisation | SENTRY_EXPORTER_TTL_ORGANISATION | 86400 | The duration in seconds to hold organisation information in memory (no request to Sentry)

--- a/cmd/listen.go
+++ b/cmd/listen.go
@@ -27,6 +27,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+var projectIncludes string
+
 // listenCmd represents the listen command
 var listenCmd = &cobra.Command{
 	Use:   "listen",
@@ -42,12 +44,24 @@ This endpoint exposes metrics from the Sentry API`,
 func init() {
 	rootCmd.AddCommand(listenCmd)
 
+	rootCmd.PersistentFlags().StringVar(
+		&projectIncludes,
+		"include-projects",
+		"",
+		"projects to include in the export (default include all projects)",
+	)
+
 	collector := sentrycollector.NewSentryCollector()
 	prometheus.MustRegister(collector)
 }
 
 func startListener() {
 	address := viper.GetString("listen_address")
+
+	if projectIncludes != "" {
+		viper.SetDefault("include_projects", projectIncludes)
+	}
+
 	// Expose the registered metrics via HTTP.
 	http.Handle("/metrics", promhttp.HandlerFor(
 		prometheus.DefaultGatherer,


### PR DESCRIPTION
Partially addresses #7 

Allows you to specify an additional parameter to limit which projects are exported (and queried from the Sentry API)