### PR TITLE
Add ability to specify which teams to export

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ You can also specify any of the settings via ENV variables.
 | listen_address | SENTRY_EXPORTER_LISTEN_ADDRESS | :9142 | Address to start the web server on
 | organisation_name | SENTRY_EXPORTER_ORGANISATION_NAME | "" | This is a **required** setting. The organisation slug for your account.  This is queried to extract a list of teams
 | project_includes | SENTRY_EXPORTER_PROJECT_INCLUDES | "" | Comma separated list of project slugs to include in the export
+| team_includes | SENTRY_EXPORTER_TEAM_INCLUDES | "" | Comma separated list of team slugs to include in the export
 | timeout | SENTRY_EXPORTER_TIMEOUT | 60 | The maximum amount of seconds to wait for the Sentry API to respond
 | token | SENTRY_EXPORTER_TOKEN | "" | This is a **required** setting. It allows communication with the Sentry API. More details below
 | ttl_organisation | SENTRY_EXPORTER_TTL_ORGANISATION | 86400 | The duration in seconds to hold organisation information in memory (no request to Sentry)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ You can also specify any of the settings via ENV variables.
 | Flag | Default | Description |
 | ---- | ------- | ----------- |
 | --config | $CURRENT_DIR/.sentry-exporter.yaml | Location of the configuration file to load
+| --include-projects | "" | Which projects should be included in the export
+| --include-teams | "" | Which teams should be included in the export
 | --loglevel | info | What level of logs should be exposed.  Options are trace, debug, info, warn, error, fatal or panic
 | --logformat | text | What format should logs be output as, human-friendly text, or computer-friendly json. Options are text or json
 | --token | "" | Allows you to specify the Sentry token via parameter instead of in config file

--- a/cmd/listen.go
+++ b/cmd/listen.go
@@ -27,8 +27,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-var projectIncludes string
-
 // listenCmd represents the listen command
 var listenCmd = &cobra.Command{
 	Use:   "listen",
@@ -44,23 +42,12 @@ This endpoint exposes metrics from the Sentry API`,
 func init() {
 	rootCmd.AddCommand(listenCmd)
 
-	rootCmd.PersistentFlags().StringVar(
-		&projectIncludes,
-		"include-projects",
-		"",
-		"projects to include in the export (default include all projects)",
-	)
-
 	collector := sentrycollector.NewSentryCollector()
 	prometheus.MustRegister(collector)
 }
 
 func startListener() {
 	address := viper.GetString("listen_address")
-
-	if projectIncludes != "" {
-		viper.SetDefault("include_projects", projectIncludes)
-	}
 
 	// Expose the registered metrics via HTTP.
 	http.Handle("/metrics", promhttp.HandlerFor(

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,8 @@ var logLevel string
 var logFormat string
 var token string
 var org string
+var projectIncludes string
+var teamIncludes string
 
 const version = "0.2.1"
 const buildDate = "2021/07/11 15:46"
@@ -84,6 +86,20 @@ func init() {
 		"organisation",
 		"",
 		"Sentry organisation to query for statistics",
+	)
+
+	rootCmd.PersistentFlags().StringVar(
+		&projectIncludes,
+		"include-projects",
+		"",
+		"projects to include in the export (default include all projects)",
+	)
+
+	rootCmd.PersistentFlags().StringVar(
+		&teamIncludes,
+		"include-teams",
+		"",
+		"teams to include in the export (default include all teams)",
 	)
 }
 
@@ -144,5 +160,13 @@ func initConfig() {
 
 	if org != "" {
 		viper.SetDefault("organisation_name", org)
+	}
+
+	if projectIncludes != "" {
+		viper.SetDefault("include_projects", projectIncludes)
+	}
+
+	if teamIncludes != "" {
+		viper.SetDefault("include_teams", teamIncludes)
 	}
 }

--- a/internal/sentrycollector/sentrycollector.go
+++ b/internal/sentrycollector/sentrycollector.go
@@ -37,6 +37,8 @@ var (
 	includeTeams    []string
 )
 
+const intialiseSentryError = "Could not initialise Sentry client"
+
 // sentryCollector implements the prometheus.Collector interface
 type sentryCollector struct {
 	projectInfo   *prometheus.Desc
@@ -230,7 +232,7 @@ func fetchOrganisation() {
 	// Create a Sentry client to query the API
 	client, err := GetSentryClient()
 	if err != nil {
-		log.Error().Err(err).Msg("Could not initialise Sentry Client")
+		log.Error().Err(err).Msg(intialiseSentryError)
 	}
 	organisation, err = client.GetOrganization(viper.GetString("organisation_name"))
 	if err != nil {
@@ -253,7 +255,7 @@ func fetchTeams() {
 	// Create a Sentry client to query the API
 	client, err := GetSentryClient()
 	if err != nil {
-		log.Error().Err(err).Msg("Could not initialise Sentry Client")
+		log.Error().Err(err).Msg(intialiseSentryError)
 	}
 	teams, err = client.GetOrganizationTeams(organisation)
 	if err != nil {
@@ -274,7 +276,7 @@ func fetchProjects() {
 	// Create a Sentry client to query the API
 	client, err := GetSentryClient()
 	if err != nil {
-		log.Error().Err(err).Msg("Could not initialise Sentry Client")
+		log.Error().Err(err).Msg(intialiseSentryError)
 	}
 	for ok := true; ok; {
 		results, link, err := client.GetOrgProjects(organisation)
@@ -299,7 +301,7 @@ func fetchErrorCount(project sentry.Project, query string) (float64, error) {
 	// Create a Sentry client to query the API
 	client, err := GetSentryClient()
 	if err != nil {
-		log.Error().Err(err).Msg("Could not initialise Sentry Client")
+		log.Error().Err(err).Msg(intialiseSentryError)
 	}
 	// Retry 3 times to fetch stats if there's a failure, with a 3s break between retries
 	for i := 0; i < 3; i++ {


### PR DESCRIPTION
Similar to the include-projects parameter, we can now specify which teams to export (which also applies the logic to which projects are exported).

For example, if team-1 owns project-1 and project-2, and team-2 owns project-2 and project-3, and you choose to export only team-1 - then project-1 and project-2 will be exported, but not project-3.

This also moves the include projects parameter to the root instead of on the listen argument.

Fixes #7 