### PR TITLE
Add internal metrics for external calls made

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ It will need the following permissions:
 | ------ | ------ | ------ |
 | sentry_project_errors | organisation, project, query | Details the number of specific error types (query) encountered by a project in an organisation
 | sentry_project_info | organisation, project, team | A purely informational/helper metric to show which teams have which projects associated with them
+| sentry_api_calls | status | Details the number of successful or failed calls made to the Sentry API
 
 Example PromQL query showing the number of errors received for a particular team, broken down by project:
 ```

--- a/internal/sentrycollector/sentrycollector.go
+++ b/internal/sentrycollector/sentrycollector.go
@@ -39,11 +39,7 @@ var (
 	apiFailureCallCount float64
 )
 
-const (
-	intialiseSentryError = "Could not initialise Sentry client"
-	successStatus        = "success"
-	failureStatus        = "failure"
-)
+const intialiseSentryError = "Could not initialise Sentry client"
 
 // sentryCollector implements the prometheus.Collector interface
 type sentryCollector struct {
@@ -140,13 +136,13 @@ func (collector *sentryCollector) Collect(ch chan<- prometheus.Metric) {
 		collector.apiCalls,
 		prometheus.GaugeValue,
 		apiSuccessCallCount,
-		successStatus,
+		"success",
 	)
 	ch <- prometheus.MustNewConstMetric(
 		collector.apiCalls,
 		prometheus.GaugeValue,
 		apiFailureCallCount,
-		failureStatus,
+		"failure",
 	)
 
 	end := time.Now().Unix()

--- a/internal/sentrycollector/sentrycollector.go
+++ b/internal/sentrycollector/sentrycollector.go
@@ -28,21 +28,28 @@ import (
 )
 
 var (
-	organisation    sentry.Organization
-	teams           []sentry.Team
-	projects        []sentry.Project
-	lastScan        = make(map[string]int64)
-	sentryClient    *sentry.Client
-	includeProjects []string
-	includeTeams    []string
+	organisation        sentry.Organization
+	teams               []sentry.Team
+	projects            []sentry.Project
+	lastScan            = make(map[string]int64)
+	sentryClient        *sentry.Client
+	includeProjects     []string
+	includeTeams        []string
+	apiSuccessCallCount float64
+	apiFailureCallCount float64
 )
 
-const intialiseSentryError = "Could not initialise Sentry client"
+const (
+	intialiseSentryError = "Could not initialise Sentry client"
+	successStatus        = "success"
+	failureStatus        = "failure"
+)
 
 // sentryCollector implements the prometheus.Collector interface
 type sentryCollector struct {
 	projectInfo   *prometheus.Desc
 	projectErrors *prometheus.Desc
+	apiCalls      *prometheus.Desc
 }
 
 // NewSentryCollector returns an instance of the sentryCollector
@@ -58,6 +65,12 @@ func NewSentryCollector() *sentryCollector {
 			"sentry_project_errors",
 			"Records the number of errors of a particular type for the specific project",
 			[]string{"organisation", "project", "query"},
+			nil,
+		),
+		apiCalls: prometheus.NewDesc(
+			"sentry_api_calls",
+			"Records the number of calls made from the exporter to the Sentry API",
+			[]string{"status"},
 			nil,
 		),
 	}
@@ -95,11 +108,14 @@ func GetSentryClient() (*sentry.Client, error) {
 func (collector *sentryCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collector.projectInfo
 	ch <- collector.projectErrors
+	ch <- collector.apiCalls
 }
 
 // Collect handles incoming metric requests
 func (collector *sentryCollector) Collect(ch chan<- prometheus.Metric) {
 	start := time.Now().Unix()
+	apiSuccessCallCount = 0
+	apiFailureCallCount = 0
 	log.Debug().Int64("now", start).Msg("Compiling metrics")
 
 	// get a slice of projects to include if specified
@@ -119,6 +135,19 @@ func (collector *sentryCollector) Collect(ch chan<- prometheus.Metric) {
 
 	exportTeams(collector, ch)
 	exportProjects(collector, ch)
+
+	ch <- prometheus.MustNewConstMetric(
+		collector.apiCalls,
+		prometheus.GaugeValue,
+		apiSuccessCallCount,
+		successStatus,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		collector.apiCalls,
+		prometheus.GaugeValue,
+		apiFailureCallCount,
+		failureStatus,
+	)
 
 	end := time.Now().Unix()
 	log.Debug().Int64("now", end).Int64("duration", end-start).Msg("Done compiling metrics")
@@ -240,8 +269,11 @@ func fetchOrganisation() {
 			Err(err).
 			Str("organisation", viper.GetString("organisation_name")).
 			Msg("Could not fetch organisation")
+		apiFailureCallCount++
+		return
 	}
 	lastScan["organisation"] = time.Now().Unix()
+	apiSuccessCallCount++
 }
 
 // fetchTeams updates the global teams object from data obtained from the
@@ -260,8 +292,11 @@ func fetchTeams() {
 	teams, err = client.GetOrganizationTeams(organisation)
 	if err != nil {
 		log.Error().Err(err).Msg("Could not fetch organisation teams")
+		apiFailureCallCount++
+		return
 	}
 	lastScan["teams"] = time.Now().Unix()
+	apiSuccessCallCount++
 }
 
 // fetchProjects updates the global projects object from data obtained from the
@@ -272,22 +307,18 @@ func fetchProjects() {
 		return
 	}
 	log.Info().Msg("Project TTL expired, refreshing")
-	projects = []sentry.Project{}
 	// Create a Sentry client to query the API
 	client, err := GetSentryClient()
 	if err != nil {
 		log.Error().Err(err).Msg(intialiseSentryError)
 	}
-	for ok := true; ok; {
-		results, link, err := client.GetOrgProjects(organisation)
-		if err != nil {
-			log.Error().Err(err).Msg("Could not fetch organisation projects")
-		}
-		projects = append(projects, results...)
-		if !link.Next.Results {
-			break
-		}
+	projects, _, err = client.GetOrgProjects(organisation)
+	if err != nil {
+		log.Error().Err(err).Msg("Could not fetch organisation projects")
+		apiFailureCallCount++
+
 	}
+	apiSuccessCallCount++
 	lastScan["projects"] = time.Now().Unix()
 }
 
@@ -320,10 +351,15 @@ func fetchErrorCount(project sentry.Project, query string) (float64, error) {
 		)
 		if err != nil {
 			// sleep for 3 seconds and try again
-			log.Debug().Msg("Could not fetch stats. Retrying")
+			log.Debug().
+				Str("project", *project.Slug).
+				Str("query", query).
+				Msg("Could not fetch stats. Retrying")
+			apiFailureCallCount++
 			time.Sleep(time.Second * 3)
 		} else {
 			err = nil
+			apiSuccessCallCount++
 			break
 		}
 	}

--- a/internal/sentrycollector/sentrycollector.go
+++ b/internal/sentrycollector/sentrycollector.go
@@ -285,12 +285,13 @@ func fetchTeams() {
 	if err != nil {
 		log.Error().Err(err).Msg(intialiseSentryError)
 	}
-	teams, err = client.GetOrganizationTeams(organisation)
+	results, err := client.GetOrganizationTeams(organisation)
 	if err != nil {
 		log.Error().Err(err).Msg("Could not fetch organisation teams")
 		apiFailureCallCount++
 		return
 	}
+	teams = results
 	lastScan["teams"] = time.Now().Unix()
 	apiSuccessCallCount++
 }
@@ -308,12 +309,13 @@ func fetchProjects() {
 	if err != nil {
 		log.Error().Err(err).Msg(intialiseSentryError)
 	}
-	projects, _, err = client.GetOrgProjects(organisation)
+	results, _, err := client.GetOrgProjects(organisation)
 	if err != nil {
 		log.Error().Err(err).Msg("Could not fetch organisation projects")
 		apiFailureCallCount++
 
 	}
+	projects = results
 	apiSuccessCallCount++
 	lastScan["projects"] = time.Now().Unix()
 }


### PR DESCRIPTION
Expose a new metric called `sentry_api_calls` which details the number of Sentry API calls made, segmented by successful and failed calls