### PR TITLE
Add flag to only export certain query types

### DIFF
--- a/.sentry-exporter-example.yaml
+++ b/.sentry-exporter-example.yaml
@@ -1,7 +1,9 @@
 api_url: http://mysentry-instance.com/api/0/  # if not specified, defaults to https://sentry.io/api/0/
 listen_address: :8080                         # if not specified, defaults to :9142
 organisation_name: my-first-organisation      # required. TODO: Obtain this via API call for default
-project_include:                              # if not specified, defaults to all projects
+include_projects:                             # if not specified, defaults to all projects
+include_queries:                              # if not specified, defaults to all queries
+include_teams:                                # if not specified, defaults to all teams
 timeout: 3                                    # if not specified, defaults to 60 seconds
 token: 12345abcdef67890ghijkl                 # required
 ttl_organisation: 600                         # if not specified, defaults to 86400 seconds (1 day)

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ You can also specify any of the settings via ENV variables.
 | api_url | SENTRY_EXPORTER_API_URL | https://sentry.io/api/0/ | URL that points to your Sentry API
 | listen_address | SENTRY_EXPORTER_LISTEN_ADDRESS | :9142 | Address to start the web server on
 | organisation_name | SENTRY_EXPORTER_ORGANISATION_NAME | "" | This is a **required** setting. The organisation slug for your account.  This is queried to extract a list of teams
-| project_includes | SENTRY_EXPORTER_PROJECT_INCLUDES | "" | Comma separated list of project slugs to include in the export
-| team_includes | SENTRY_EXPORTER_TEAM_INCLUDES | "" | Comma separated list of team slugs to include in the export
+| include_projects | SENTRY_EXPORTER_INCLUDE_PROJECTS | "" | Comma separated list of project slugs to include in the export
+| include_queries | SENTRY_EXPORTER_INCLUDE_QUERIES | "" | Comma separated list of query types to include in the export (valid options: generated, blacklisted, received, rejected)
+| include_teams | SENTRY_EXPORTER_INCLUDE_TEAMS | "" | Comma separated list of team slugs to include in the export
 | timeout | SENTRY_EXPORTER_TIMEOUT | 60 | The maximum amount of seconds to wait for the Sentry API to respond
 | token | SENTRY_EXPORTER_TOKEN | "" | This is a **required** setting. It allows communication with the Sentry API. More details below
 | ttl_organisation | SENTRY_EXPORTER_TTL_ORGANISATION | 86400 | The duration in seconds to hold organisation information in memory (no request to Sentry)
@@ -32,6 +33,7 @@ You can also specify any of the settings via ENV variables.
 | ---- | ------- | ----------- |
 | --config | $CURRENT_DIR/.sentry-exporter.yaml | Location of the configuration file to load
 | --include-projects | "" | Which projects should be included in the export
+| --include-queries | "" | Which query types should be included in the export.  Options are generated, blacklisted, received, or rejected
 | --include-teams | "" | Which teams should be included in the export
 | --loglevel | info | What level of logs should be exposed.  Options are trace, debug, info, warn, error, fatal or panic
 | --logformat | text | What format should logs be output as, human-friendly text, or computer-friendly json. Options are text or json

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,6 +34,7 @@ var token string
 var org string
 var projectIncludes string
 var teamIncludes string
+var queryIncludes string
 
 const version = "0.2.1"
 const buildDate = "2021/07/11 15:46"
@@ -100,6 +101,13 @@ func init() {
 		"include-teams",
 		"",
 		"teams to include in the export (default include all teams)",
+	)
+
+	rootCmd.PersistentFlags().StringVar(
+		&queryIncludes,
+		"include-queries",
+		"",
+		"queries to include in the export (default include all teams)",
 	)
 }
 
@@ -168,5 +176,9 @@ func initConfig() {
 
 	if teamIncludes != "" {
 		viper.SetDefault("include_teams", teamIncludes)
+	}
+
+	if queryIncludes != "" {
+		viper.SetDefault("include_queries", queryIncludes)
 	}
 }


### PR DESCRIPTION
Yet another option on how to split the export across multiple containers, or to restrict the metrics.

Now you can specify which query types should be included in the metrics: `generated`, `blacklisted`, `received` and `rejected`

Also fixed some README entries and examples.