### PR TITLE
Integrate workflows for Docker pushes

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,9 +1,11 @@
-name: Build
+name: ci
+
 on:
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+    branches:
+      - 'master'
+    tags:
+      - 'v*'
 
 jobs:
   go:
@@ -37,11 +39,16 @@ jobs:
         name: Checkout
         uses: actions/checkout@v2
       -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: maggotmouth/sentry-exporter
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
       -
         name: Download artifact
         uses: actions/download-artifact@v2
@@ -50,6 +57,7 @@ jobs:
           path: bin/sentry-exporter
       -
         name: Login to DockerHub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -59,5 +67,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: true
-          tags: maggotmouth/sentry-exporter:test
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: Build
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  go:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set Up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.16.3'
+      -
+        name: Checkout
+        uses: actions/checkout@master
+      -
+        name: Get Dependencies
+        run: go mod download
+      -
+        name: Build
+        run: CGO_ENABLED=0 GOOS=linux go build -o bin/sentry-exporter
+      -
+        name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: sentry-exporter
+          path: bin/sentry-exporter
+  docker:
+    needs: [go]
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: sentry-exporter
+          path: bin/sentry-exporter
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: sentry-exporter:test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,9 +49,6 @@ jobs:
           name: sentry-exporter
           path: bin/sentry-exporter
       -
-        name: Display structure of downloaded files
-        run: ls -R
-      -
         name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -59,9 +56,8 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
-        id: docker_build
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
-          tags: sentry-exporter:test
+          tags: maggotmouth/sentry-exporter:test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       -
@@ -59,5 +62,6 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
+          context: .
           push: true
           tags: sentry-exporter:test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,9 @@ jobs:
           name: sentry-exporter
           path: bin/sentry-exporter
       -
+        name: Display structure of downloaded files
+        run: ls -R
+      -
         name: Login to DockerHub
         uses: docker/login-action@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /cover.out
 /coverage.html
 /tools
-/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:alpine
+
+COPY ./bin/sentry-exporter /
+
+ENTRYPOINT ["/sentry-exporter"]
+CMD ["listen", "--loglevel=debug"]


### PR DESCRIPTION
Created a workflow to perform:
* a go build
* a docker build
* a docker push

For commits to master as well as new tags being pushed (prefixed by `v*`