### PR TITLE
Fix for workflow running on master instead of main

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
     tags:
       - 'v*'
 


### PR DESCRIPTION
The workflow incorrectly references the `master` branch instead of the `main` branch.  This PR fixes that.